### PR TITLE
Add simultaneous playback button

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,7 @@
     .file-select { margin-bottom: 10px; }
     .file-select select { width: 45%; margin-right: 5px; }
     .file-select input[type="file"] { width: 45%; margin-right: 5px; }
+    .play-controls { margin-bottom: 10px; }
     #usage div { margin-bottom: 4px; }
     #usage progress {
       width: 60%;
@@ -72,6 +73,9 @@
     </div>
     {% if has_results %}
     <p>スイングスコア: {{ "%.4f"|format(score) }}</p>
+    <div class="play-controls">
+      <button id="play-both-btn">同時再生</button>
+    </div>
     <div class="video-wrapper">
       <div class="video-item">
         <video id="ref-video" controls loop>
@@ -413,6 +417,19 @@
     if (HAS_RESULTS) {
       setupCanvas('ref-video', 'ref-canvas', REF_KP_URL);
       setupCanvas('cur-video', 'cur-canvas', CUR_KP_URL);
+      const playBtn = document.getElementById('play-both-btn');
+      if (playBtn) {
+        playBtn.addEventListener('click', () => {
+          const ref = document.getElementById('ref-video');
+          const cur = document.getElementById('cur-video');
+          if (ref && cur) {
+            ref.currentTime = 0;
+            cur.currentTime = 0;
+            ref.play();
+            cur.play();
+          }
+        });
+      }
     }
     if (document.getElementById('chat-input')) {
       init_chat();


### PR DESCRIPTION
## Summary
- Add a play-both button to start reference and target videos together
- Wire up event listener resetting playback to sync videos

## Testing
- `python test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b10adc3778832e8b10d02ff5251408