### PR TITLE
Add stop playback control and hide file input text

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,13 @@
     .video-item canvas { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; }
     .file-select { margin-bottom: 10px; }
     .file-select select { width: 45%; margin-right: 5px; }
-    .file-select input[type="file"] { width: 45%; margin-right: 5px; }
+    .file-select input[type="file"] {
+      margin-right: 5px;
+      font-size: 0;
+    }
+    .file-select input[type="file"]::file-selector-button {
+      font-size: 14px;
+    }
     .play-controls { margin-bottom: 10px; }
     #usage div { margin-bottom: 4px; }
     #usage progress {
@@ -75,6 +81,7 @@
     <p>スイングスコア: {{ "%.4f"|format(score) }}</p>
     <div class="play-controls">
       <button id="play-both-btn">同時再生</button>
+      <button id="stop-both-btn">停止</button>
     </div>
     <div class="video-wrapper">
       <div class="video-item">
@@ -427,6 +434,19 @@
             cur.currentTime = 0;
             ref.play();
             cur.play();
+          }
+        });
+      }
+      const stopBtn = document.getElementById('stop-both-btn');
+      if (stopBtn) {
+        stopBtn.addEventListener('click', () => {
+          const ref = document.getElementById('ref-video');
+          const cur = document.getElementById('cur-video');
+          if (ref && cur) {
+            ref.pause();
+            cur.pause();
+            ref.currentTime = 0;
+            cur.currentTime = 0;
           }
         });
       }


### PR DESCRIPTION
## Summary
- Add button to stop both videos and reset playback
- Hide default "no file chosen" text on file inputs for cleaner UI

## Testing
- `python -m py_compile app.py simple_chatbot.py golf_swing_compare.py test.py`
- ⚠️ `python test.py` (importing torch triggered a KeyboardInterrupt)


------
https://chatgpt.com/codex/tasks/task_e_68b10cb01608832e945074bf74be95b1