### PR TITLE
Link overall swing score to phase scores

### DIFF
--- a/app.py
+++ b/app.py
@@ -275,7 +275,7 @@ def _prepare_videos_sync() -> None:
         # Compute similarity score and produce annotated videos/JSON files
         flask_app.logger.info("Computing swing similarity score...")
         try:
-            score = compare_swings(ref_keypoints, cur_keypoints)
+            score, _ = compare_swings(ref_keypoints, cur_keypoints)
             flask_app.logger.info(f"Computed score: {score}")
         except Exception as e:
             flask_app.logger.error(f"Failed to compute swing score: {e}")


### PR DESCRIPTION
## Summary
- compute per-phase swing scores and average them for the overall score
- expose phase scores via `GolfSwingAnalyzer` results
- update app to handle new return values

## Testing
- `python -m pytest`
- `python test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b67d502fac832ea1d3f4a88597cd4b