### PR TITLE
Show score before advice in swing analysis

### DIFF
--- a/golf_swing_compare.py
+++ b/golf_swing_compare.py
@@ -465,13 +465,16 @@ class EnhancedSwingChatBot:
             f" • ダウンスイング: {phases.get('downswing', 0.0):.3f}\n"
             f" • フォロースルー: {phases.get('follow_through', 0.0):.3f}"
         )
+        advice = self._generate_advice()
+        full = f"{base}\n\n📋 アドバイス:\n{advice}"
         try:
-            # Let the simple chatbot rephrase the summary for a more natural tone
+            # Let the simple chatbot rephrase the summary but keep score first
             return self._simple_bot.ask(
-                "以下のゴルフスイング解析結果を分かりやすい文章で伝えてください:\n" + base
+                "以下のスコアとアドバイスをこの順番で分かりやすく伝えてください。スコアを先に、続いてアドバイスを述べてください:\n"
+                + full
             )
         except Exception:
-            return base
+            return full
 
     def _generate_advice(self) -> str:
         phases = self.analysis.get("swing_phases", {})


### PR DESCRIPTION
## Summary
- Append swing advice after the score summary so users see their score before recommendations.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6db77b490832e822a68f0bb7c2f22