### PR TITLE
Load chatbot model in 8-bit

### DIFF
--- a/simple_chatbot.py
+++ b/simple_chatbot.py
@@ -15,7 +15,10 @@ class SimpleChatBot:
                 model_name, trust_remote_code=True
             )
             self.model = AutoModelForCausalLM.from_pretrained(
-                model_name, trust_remote_code=True
+                model_name,
+                trust_remote_code=True,
+                load_in_8bit=True,
+                device_map="auto",
             )
         except Exception:  # pragma: no cover - network-related
             # Fallback to a trivial echo mode if the model can't be downloaded.


### PR DESCRIPTION
## Summary
- Load SimpleChatBot's language model in 8-bit with automatic device mapping

## Testing
- `python -m py_compile simple_chatbot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6e686bc9c832e8ef6686a5faa860a