### PR TITLE
feat: apply Intel-themed color palette

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,12 +5,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>チャット & 動画</title>
   <style>
+    :root {
+      --intel-blue: #0071C5;
+      --intel-light-blue: #00AEEF;
+      --intel-bg: #f5f5f5;
+      --intel-text: #000;
+    }
+
     body {
       display: flex;
       height: 100vh;
       margin: 0;
-      background: #1e1e1e;
-      color: #f5f5f5;
+      background: var(--intel-bg);
+      color: var(--intel-text);
     }
     .video-container, .chat-container { flex: 1; padding: 10px; box-sizing: border-box; }
     .chat-container { display: flex; flex-direction: column; }
@@ -27,14 +34,14 @@
       font-weight: bold;
     }
     .chat-status.preparing { background: #fff3cd; color: #856404; }
-    .chat-status.ready { background: #d4edda; color: #155724; }
+    .chat-status.ready { background: var(--intel-blue); color: #fff; }
     .chat-status.error { background: #f8d7da; color: #721c24; }
     .video-wrapper { display: flex; }
     .video-item { position: relative; flex: 1; }
     .video-item video { width: 100%; display: block; }
     .video-item canvas { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; }
-    .video-item.pro video { border: 4px solid #ffd700; }
-    .video-item.target video { border: 4px solid #00bfff; }
+    .video-item.pro video { border: 4px solid var(--intel-blue); }
+    .video-item.target video { border: 4px solid var(--intel-light-blue); }
     .video-item.pro::before,
     .video-item.target::before {
       position: absolute;
@@ -46,8 +53,8 @@
       font-weight: bold;
       z-index: 1;
     }
-    .video-item.pro::before { content: 'プロ'; background: rgba(255, 215, 0, 0.8); }
-    .video-item.target::before { content: '対象'; background: rgba(30, 144, 255, 0.8); }
+    .video-item.pro::before { content: 'プロ'; background: rgba(0, 113, 197, 0.8); }
+    .video-item.target::before { content: '対象'; background: rgba(0, 174, 239, 0.8); }
     .file-select { margin-bottom: 10px; }
     .file-select select { width: 45%; margin-right: 5px; }
     .file-select input[type="file"] {
@@ -71,8 +78,8 @@
     .usage-item {
       display: flex;
       align-items: center;
-      background: #2c2c2c;
-      border: 1px solid #444;
+      background: #ffffff;
+      border: 1px solid #ccc;
       border-radius: 8px;
       padding: 8px 10px;
       box-shadow: none;
@@ -93,9 +100,10 @@
       --bar-color: green;
       border-radius: 8px;
       overflow: hidden;
+      background-color: #ddd;
     }
     .usage-item progress::-webkit-progress-bar {
-      background-color: #444;
+      background-color: #ddd;
       border-radius: 8px;
     }
     .usage-item progress::-webkit-progress-value {
@@ -113,7 +121,7 @@
     }
     .usage-item .detail {
       margin-left: 4px;
-      color: #bbb;
+      color: #666;
       font-size: 0.85em;
     }
     .usage-item .value-detail {


### PR DESCRIPTION
## Summary
- switch frontend to light Intel-style palette
- add Intel blue accents for videos and chat ready status
- refresh usage panel with light backgrounds

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6f762a248832eb21d14f7371a395c