### PR TITLE
docs: clarify LLM usage in chatbot

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ A minimal FastAPI application displays reference and test videos next to a chat 
 
 ## Simple Web Chatbot
 
-A lightweight general-purpose chatbot is available at `http://localhost:8000/chat`. It uses a small DialoGPT model and stores the conversation only for the current session.
+A lightweight general-purpose chatbot is available at `http://localhost:8000/chat`. It uses the modular `simple_chatbot.py` LLM wrapper (default: Qwen2.5 3B Instruct via OpenVINO) and stores the conversation only for the current session.
 
 Backend selection and env vars:
 - `LLM_BACKEND`: `auto | transformers | llama | openvino` (default: `openvino`)

--- a/docs/requirements_design.md
+++ b/docs/requirements_design.md
@@ -48,7 +48,7 @@
 
 
 7. **一般向けチャット**
-   - DialoGPTベースの軽量チャットボットを `/chat` ページで提供する
+    - `simple_chatbot.py` に基づく軽量LLMチャットボットを `/chat` ページで提供する（デフォルトは OpenVINO で動作する Qwen 系モデル）
 
 
 
@@ -108,7 +108,7 @@
 
 
 3. **simple_chatbot.py**
-   - `SimpleChatBot`がDialoGPTモデルをロードし、会話履歴を維持しながら応答を生成する
+    - `SimpleChatBot` が Qwen などのLLMをバックエンド経由でロードし、会話履歴を維持しながら応答を生成する
 
 
 


### PR DESCRIPTION
## Summary
- Update README to explain that the web chatbot uses `simple_chatbot.py` with a Qwen LLM by default
- Revise design doc to replace DialoGPT references with the new OpenVINO-based LLM chatbot

## Testing
- `python -m py_compile app.py simple_chatbot.py backend/services/chatbot_service.py backend/services/swing_chatbot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b96dff7778832eb2b31bd921edeff9