### PR TITLE
refactor: replace deprecated openvino.runtime import

### DIFF
--- a/backend/inference/openpose.py
+++ b/backend/inference/openpose.py
@@ -53,7 +53,7 @@ class OpenVinoPoseExtractor(PoseExtractor):
         cached = _MODEL_CACHE.get(key)
         if cached is not None:
             return cached
-        from openvino.runtime import Core
+        from openvino import Core
 
         core = Core()
         model = core.read_model(model=model_xml)


### PR DESCRIPTION
## Summary
- switch pose extraction to `openvino.Core` to avoid deprecation warning

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68b97cf79958832e8cd268bf679510e0