### PR TITLE
Use bartowski Qwen2.5-1.5B GGUF model by default

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ This project compares two golf swing videos with OpenVINO and includes a web int
  Notes on models and backends:
  - Pose model default path is `intel/human-pose-estimation-0001/FP16/human-pose-estimation-0001.xml` (see `backend/config.py:Settings.MODEL_XML`). Adjust if your IR is elsewhere or a different precision.
  - General chatbot backends supported: `transformers` (HF), `llama.cpp` (GGUF), and `OpenVINO GenAI`. Select via `LLM_BACKEND` env var: `auto | transformers | llama | openvino` (default: `openvino`).
-  - When using OpenVINO with GGUF, the app can auto-download the model (via `huggingface_hub`) and auto-convert the tokenizer (via `openvino-tokenizers`) when you pass a repo id like `Qwen/Qwen2.5-1.5B-Instruct-GGUF`.
+  - When using OpenVINO with GGUF, the app can auto-download the model (via `huggingface_hub`) and auto-convert the tokenizer (via `openvino-tokenizers`) when you pass a repo id like `bartowski/Qwen2.5-1.5B-Instruct-GGUF`.
 
 ## Installation
 
@@ -47,7 +47,7 @@ A lightweight general-purpose chatbot is available at `http://localhost:8000/cha
 
 Backend selection and env vars:
 - `LLM_BACKEND`: `auto | transformers | llama | openvino` (default: `openvino`)
-- `CHAT_MODEL`: HF repo/model id (e.g., `Qwen/Qwen2.5-1.5B-Instruct` or `Qwen/Qwen2.5-1.5B-Instruct-GGUF`)
+- `CHAT_MODEL`: HF repo/model id (e.g., `bartowski/Qwen2.5-1.5B-Instruct-GGUF`)
 - `CHAT_GGUF_FILENAME`: when using GGUF backends (e.g., `qwen2.5-1.5b-instruct-q4_k_m.gguf`)
 - `TOKENIZER_ID`: optional override for tokenizer source when auto-converting (default: drop `-GGUF` from `CHAT_MODEL`).
 - `DEVICE`: OpenVINO device for pose model (`CPU`, `GPU`, etc.; default `CPU`)
@@ -70,7 +70,7 @@ Use these commands to prepare local model files in the `models` directory.
 - Download LLM model:
 
 ```
-huggingface-cli download Qwen/Qwen2.5-1.5B-Instruct-GGUF qwen2.5-1.5b-instruct-q4_k_m.gguf --local-dir models
+huggingface-cli download bartowski/Qwen2.5-1.5B-Instruct-GGUF qwen2.5-1.5b-instruct-q4_k_m.gguf --local-dir models
 ```
 
 - Convert tokenizer with detokenizer:

--- a/backend/simple_chatbot/simple_chatbot.py
+++ b/backend/simple_chatbot/simple_chatbot.py
@@ -649,7 +649,7 @@ def parse_args():
         help=(
             "Model to use. Default: 'openvion' sentinel which maps to "
             "bartowski/Qwen2.5-1.5B-Instruct-GGUF with GGUF 'Qwen2.5-1.5B-Instruct-Q4_K_M.gguf'. "
-            "Also accepts repo id (e.g. 'Qwen/Qwen2.5-1.5B-Instruct-GGUF'), 'echo', or "
+            "Also accepts repo id (e.g. 'bartowski/Qwen2.5-1.5B-Instruct-GGUF'), 'echo', or "
             "'openvino:<path_to_ov_or_gguf>'."
         )
     )

--- a/scripts/download_model.ps1
+++ b/scripts/download_model.ps1
@@ -1,5 +1,5 @@
 param(
-  [string]$RepoId = "Qwen/Qwen2.5-1.5B-Instruct-GGUF",
+  [string]$RepoId = "bartowski/Qwen2.5-1.5B-Instruct-GGUF",
   [string]$Filename = "qwen2.5-1.5b-instruct-q4_k_m.gguf",
   [string]$LocalDir = "models"
 )


### PR DESCRIPTION
## Summary
- default to bartowski/Qwen2.5-1.5B-Instruct-GGUF in model download script
- document bartowski repo for chat model and huggingface-cli instructions
- CLI help now shows bartowski/Qwen2.5-1.5B-Instruct-GGUF example

## Testing
- `pytest -q`
- `python test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b981b3b4b4832e8ef9d50a55841bb9