### PR TITLE
Enable streaming for chatbot responses

### DIFF
--- a/backend/services/swing_chatbot.py
+++ b/backend/services/swing_chatbot.py
@@ -104,5 +104,15 @@ class EnhancedSwingChatBot:
         except Exception:
             return self._generate_advice()
 
+    def ask_stream(self, message: str):
+        """Yield a reply incrementally for streaming clients."""
+        try:
+            for chunk in self._simple_bot.ask_stream(message):
+                yield chunk
+        except Exception:
+            advice = self._generate_advice()
+            for ch in advice:
+                yield ch
+
 
 __all__ = ["EnhancedSwingChatBot"]

--- a/backend/simple_chatbot/simple_chatbot.py
+++ b/backend/simple_chatbot/simple_chatbot.py
@@ -592,6 +592,23 @@ class SimpleChatBot:
         """Generate a reply for ``message`` using the underlying model."""
         return self._model.generate_response(message)
 
+    def ask_stream(self, message: str):
+        """Yield a reply incrementally.
+
+        This is a simple wrapper around :meth:`ask` that yields the final
+        response one character at a time.  If the underlying model provides a
+        ``generate_response_stream`` method, it will be used instead to allow
+        token-level streaming.
+        """
+        gen = getattr(self._model, "generate_response_stream", None)
+        if callable(gen):
+            for chunk in gen(message):
+                yield chunk
+        else:
+            reply = self.ask(message)
+            for ch in reply:
+                yield ch
+
     # Expose optional hooks when available
     def set_system_prompt(self, prompt: str) -> None:
         model = self._model


### PR DESCRIPTION
## Summary
- Add streaming support to general and swing chatbots
- Expose `ask_stream` in chatbot implementations and use in API routes

## Testing
- `python -m py_compile app.py backend/services/chatbot_service.py backend/services/swing_chatbot.py backend/simple_chatbot/simple_chatbot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b994cd9df8832e9df3bf4e3327bd85