### PR TITLE
feat: add websocket streaming

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pynvml
 jinja2
 aiofiles
 python-multipart
+websockets


### PR DESCRIPTION
## Summary
- stream chatbot responses over WebSockets instead of SSE
- add WebSocket client helper in frontend
- include websockets dependency

## Testing
- `python -m pytest`
- `python -m py_compile app.py backend/services/chatbot_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9978fe340832ebc920e6682ae2481