### PR TITLE
Add standalone general chatbot page

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,6 +165,12 @@ def index(request: Request):
         },
     )
 
+
+@app.get("/chat", response_class=HTMLResponse)
+def chat_page(request: Request):
+    """Serve the standalone general-purpose chatbot page."""
+    return templates.TemplateResponse("chat.html", {"request": request})
+
 @app.api_route("/chat_messages", methods=["GET", "POST"])
 async def chat_messages_handler(request: Request):
     """Handle messages for the general-purpose chatbot."""

--- a/static/js/general_chat.js
+++ b/static/js/general_chat.js
@@ -1,0 +1,47 @@
+const box = document.getElementById('chat-messages');
+const input = document.getElementById('chat-input');
+const btn = document.getElementById('send-btn');
+
+function append(role, text) {
+  const p = document.createElement('p');
+  const prefix = role === 'user' ? 'あなた: ' : 'AI: ';
+  p.textContent = prefix + text;
+  p.className = 'chat-msg';
+  box.appendChild(p);
+  box.scrollTop = box.scrollHeight;
+}
+
+async function loadMessages() {
+  try {
+    const res = await fetch('/chat_messages');
+    const msgs = await res.json();
+    msgs.forEach(m => append(m.role, m.content));
+  } catch (err) {
+    console.error('Failed to load messages', err);
+  }
+}
+
+async function send() {
+  const text = input.value.trim();
+  if (!text) return;
+  append('user', text);
+  input.value = '';
+  try {
+    const res = await fetch('/chat_messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: text })
+    });
+    const data = await res.json();
+    append('assistant', data.reply || '');
+  } catch (err) {
+    append('assistant', 'エラーが発生しました');
+  }
+}
+
+btn.addEventListener('click', send);
+input.addEventListener('keydown', e => {
+  if (e.key === 'Enter') send();
+});
+
+loadMessages();

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>シンプルチャットボット</title>
+  <link rel="stylesheet" href="{{ request.url_for('static', path='css/styles.css') }}">
+</head>
+<body>
+  <div class="chat-container">
+    <div id="chat-messages"></div>
+    <div class="chat-input">
+      <input id="chat-input" type="text" placeholder="メッセージを入力..." />
+      <button id="send-btn">送信</button>
+    </div>
+  </div>
+  <script type="module" src="{{ request.url_for('static', path='js/general_chat.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/chat` endpoint serving new chat HTML template
- implement simple frontend script for general chatbot interactions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b999cb3e30832ebbc965c0464642d4