### PR TITLE
style: differentiate chat message backgrounds

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -16,6 +16,9 @@ body {
 .chat-container { display: flex; flex-direction: column; }
 #chat-messages { flex: 1; border: 1px solid #ccc; overflow-y: auto; margin-bottom: 10px; padding: 5px; }
 #chat-messages p { white-space: pre-wrap; margin: 6px 0; }
+#chat-messages .chat-msg { padding: 4px 8px; border-radius: 4px; }
+#chat-messages .user-msg { background: #e6f7ff; }
+#chat-messages .assistant-msg { background: #f0f0f0; }
 .chat-input { display: flex; }
 .chat-input input { flex: 1; padding: 5px; }
 .chat-input button { margin-left: 5px; }

--- a/static/js/chat/chatController.js
+++ b/static/js/chat/chatController.js
@@ -19,6 +19,7 @@ export class ChatController {
       p.id = 'init-loading';
       p.textContent = 'コーチ: メッセージ生成中...';
       p.style.opacity = '0.7';
+      p.className = 'chat-msg assistant-msg';
       this.box.appendChild(p);
       this.box.scrollTop = this.box.scrollHeight;
     }
@@ -82,7 +83,7 @@ export class ChatController {
         const p = document.createElement('p');
         const prefix = m.role === 'user' ? 'あなた: ' : 'コーチ: ';
         p.textContent = prefix + m.content;
-        p.className = 'chat-msg';
+        p.className = 'chat-msg ' + (m.role === 'user' ? 'user-msg' : 'assistant-msg');
         this.box.appendChild(p);
       });
       this.box.scrollTop = this.box.scrollHeight;
@@ -100,11 +101,13 @@ export class ChatController {
       if (!text) return;
       const userP = document.createElement('p');
       userP.textContent = 'あなた: ' + text;
+      userP.className = 'chat-msg user-msg';
       this.box.appendChild(userP);
       this.input.value = '';
 
       const coachP = document.createElement('p');
       coachP.textContent = 'コーチ: ';
+      coachP.className = 'chat-msg assistant-msg';
       this.box.appendChild(coachP);
       this.box.scrollTop = this.box.scrollHeight;
 

--- a/static/js/general_chat.js
+++ b/static/js/general_chat.js
@@ -6,7 +6,7 @@ function append(role, text) {
   const p = document.createElement('p');
   const prefix = role === 'user' ? 'あなた: ' : 'AI: ';
   p.textContent = prefix + text;
-  p.className = 'chat-msg';
+  p.classList.add('chat-msg', role === 'user' ? 'user-msg' : 'assistant-msg');
   box.appendChild(p);
   box.scrollTop = box.scrollHeight;
 }
@@ -15,7 +15,7 @@ function appendTyping(role, text, speed = 30) {
   const p = document.createElement('p');
   const prefix = role === 'user' ? 'あなた: ' : 'AI: ';
   p.textContent = prefix;
-  p.className = 'chat-msg';
+  p.classList.add('chat-msg', role === 'user' ? 'user-msg' : 'assistant-msg');
   box.appendChild(p);
   box.scrollTop = box.scrollHeight;
   let i = 0;


### PR DESCRIPTION
## Summary
- style chat messages with different backgrounds for coach vs user
- add role-specific classes in JS to apply the new styling

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baeac29464832e8bc7cea5b144c7f2