### PR TITLE
Add chatbot backend selector

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,6 +167,7 @@ def index(request: Request):
             "has_results": has_results,
             "chatbot_enabled": is_chatbot_enabled(),
             "device": analysis.device,
+            "llm_backend": settings.LLM_BACKEND,
         },
     )
 
@@ -435,14 +436,19 @@ async def set_videos(request: Request):
     ref_file = data.get("reference_file")
     cur_file = data.get("current_file")
     device = (data.get("device") or "").upper()
+    backend = (data.get("backend") or "").lower()
 
     analysis.set_videos(ref_file, cur_file, device)
     chat.clear_swing()
+    if backend:
+        settings.LLM_BACKEND = backend
+        os.environ["LLM_BACKEND"] = backend
+        chat.general_clear()
 
     logger.info(
-        f"Videos set to: ref={analysis.ref_video.name}, cur={analysis.cur_video.name}, device={analysis.device}"
+        f"Videos set to: ref={analysis.ref_video.name}, cur={analysis.cur_video.name}, device={analysis.device}, backend={settings.LLM_BACKEND}"
     )
-    return JSONResponse({"status": "ok", "device": analysis.device})
+    return JSONResponse({"status": "ok", "device": analysis.device, "backend": settings.LLM_BACKEND})
 
 
 @app.get("/chatbot_status")

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -8,7 +8,7 @@ import { VideoSelectorController } from './ui/videoSelector.js';
 const cfg = window.APP_CONFIG || {};
 
 // Initialize video selector and analysis flow
-const videoSelector = new VideoSelectorController({ currentDevice: cfg.device, hasChat: cfg.chatbotEnabled });
+const videoSelector = new VideoSelectorController({ currentDevice: cfg.device, hasChat: cfg.chatbotEnabled, backend: cfg.llmBackend });
 await videoSelector.loadList();
 videoSelector.setDefaults({ refName: cfg.refVideoName, curName: cfg.curVideoName });
 videoSelector.bindProcess();

--- a/static/js/services/api.js
+++ b/static/js/services/api.js
@@ -35,8 +35,8 @@ export async function uploadVideos({ reference, current }) {
   return res.json();
 }
 
-export function setVideos({ reference_file, current_file, device }) {
-  return postJson('/set_videos', { reference_file, current_file, device });
+export function setVideos({ reference_file, current_file, device, backend }) {
+  return postJson('/set_videos', { reference_file, current_file, device, backend });
 }
 
 export async function analyze() {

--- a/static/js/ui/videoSelector.js
+++ b/static/js/ui/videoSelector.js
@@ -1,8 +1,9 @@
 import { listVideos, uploadVideos, setVideos, analyze } from '../services/api.js';
 
 export class VideoSelectorController {
-  constructor({ currentDevice, hasChat }) {
+  constructor({ currentDevice, hasChat, backend }) {
     this.currentDevice = currentDevice;
+    this.currentBackend = backend;
     this.hasChat = hasChat;
   }
 
@@ -23,9 +24,11 @@ export class VideoSelectorController {
     const refSel = document.getElementById('ref-file');
     const curSel = document.getElementById('cur-file');
     const devSel = document.getElementById('device-select');
+    const backendSel = document.getElementById('backend-select');
     if (refSel) refSel.value = refName || '';
     if (curSel) curSel.value = curName || '';
     if (devSel) devSel.value = this.currentDevice || 'CPU';
+    if (backendSel) backendSel.value = this.currentBackend || 'auto';
   }
 
   bindProcess() {
@@ -37,6 +40,7 @@ export class VideoSelectorController {
       const refSel = document.getElementById('ref-file').value;
       const curSel = document.getElementById('cur-file').value;
       const device = document.getElementById('device-select').value;
+      const backend = document.getElementById('backend-select').value;
 
       let refFile = refSel, curFile = curSel;
       if (refUp || curUp) {
@@ -45,7 +49,7 @@ export class VideoSelectorController {
         if (uploaded.current_file) curFile = uploaded.current_file;
       }
 
-      await setVideos({ reference_file: refFile, current_file: curFile, device });
+      await setVideos({ reference_file: refFile, current_file: curFile, device, backend });
 
       const status = document.getElementById('status');
       if (status) status.textContent = '動画解析中です。完了までお待ちください';

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,6 +28,14 @@
         <option value="NPU">NPU</option>
       </select>
       <br />
+      <label for="backend-select">バックエンド</label>
+      <select id="backend-select">
+        <option value="auto">Auto</option>
+        <option value="openvino">OpenVINO</option>
+        <option value="llama">llama.cpp</option>
+        <option value="transformers">Transformers</option>
+      </select>
+      <br />
       <button id="process-btn">更新</button>
     </div>
     <div id="status"></div>
@@ -90,6 +98,7 @@
       hasResults: {{ 'true' if has_results else 'false' }},
       chatbotEnabled: {{ 'true' if chatbot_enabled else 'false' }},
       device: '{{ device }}',
+      llmBackend: '{{ llm_backend }}',
       refKpUrl: '{{ request.url_for('static', path=ref_kp_name) }}',
       curKpUrl: '{{ request.url_for('static', path=cur_kp_name) }}',
       refVideoName: '{{ ref_video_name }}',


### PR DESCRIPTION
## Summary
- Add LLM backend selection dropdown to main page
- Wire selection through frontend, API, and backend for runtime switching

## Testing
- `python -m pytest`
- `python test.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb8ede7f50832ea033d1510716cb7c